### PR TITLE
the value of this was not defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ module.exports = {
       throw new Error('output dir missing');
     }
 
-    this.src(o)
+    module.exports.src(o)
       .on('error', handleCallbackError(cb))
       .pipe(vfs.dest(function (file) {
         return file.base;


### PR DESCRIPTION
When we call create(), we get an error that "this" is not defined. Changing "this" to "module.exports" makes the method more error-proof.
